### PR TITLE
Simplify design of the base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 Batch processing for image-analysis on high-throughput screening data; developed for covid19 antibody test set-up.
 
-## Run Analysis Workflows
+## Installation
+
+- install the conda environment via `conda env create -f environment-gpu.yaml` or `conda env create -f environment-gpu.yaml -n custom_env_name`.
+- activate the environment and install `batchlib` using `setup.py`, e.g. via running `pip install -e .` in this directory to install in development mode
+- to check your installation, go to the `antibodies` directory and run the following example:
+``` sh
+python instance_analysis_workflow2.py /home/covid19/data/covid-data-vibor/test <GPU_ID> <N_CPUS> --folder test
+```
+This should run through without throwing an error and create a folder `test` locally containing 9 h5 files with the results per image.
+
+Note: stardist might have issues with newer GCC versions (GCC 9 fails, GCC 7 works)
+
+## Usage & Development
+
+### Run Analysis Workflows
 
 The analysis for antibody screening are in `antibodies`. To run them on IALGPU03, give the path to the input folder and pass optional parameters.
 To run the pixel based analysis workflow (set `n_jobs` to control the number of worker threads):
@@ -13,12 +27,6 @@ To run the instance segmentation based analysis workflow:
 ```sh
 ./instance_analysis_workflow1.py /path/to/input-folder --n_jobs 8
 ```
-
-## Installation
-
-Note: stardist does not work with newer GCC versions (GCC 9 fails, GCC 7 works)
-
-## Usage & Development
 
 `batchlib` operates on a single folder containing the data to process in this batch.
 Its workflows consist of indvidual jobs that apply an operation to files matching a pattern.

--- a/antibodies/instance_analysis_workflow2.py
+++ b/antibodies/instance_analysis_workflow2.py
@@ -13,11 +13,14 @@ from batchlib.segmentation.torch_prediction import TorchPrediction
 from batchlib.segmentation.unet import UNet2D
 from batchlib.analysis.cell_level_analysis import CellLevelAnalysis
 
+ROOT = '/home/covid19/antibodies-nuclei'
+# ROOT = '/g/kreshuk/pape/Work/covid/antibodies-nuclei'
+
 
 # TODO all kwargs should go into config file
 # NOTE ignore_nvalid_inputs / ignore_failed_outputs are not used yet in the function but will be eventually
 def run_instance_analysis2(input_folder, folder, gpu, n_cpus, batch_size=4,
-                           root='/home/covid19/antibodies-nuclei', output_root_name='data-processed',
+                           root=ROOT, output_root_name='data-processed',
                            use_unique_output_folder=False,
                            force_recompute=False, ignore_invalid_inputs=None, ignore_failed_outputs=None):
     name = 'InstanceAnalysisWorkflow2'

--- a/batchlib/analysis/cell_level_analysis.py
+++ b/batchlib/analysis/cell_level_analysis.py
@@ -102,7 +102,6 @@ class CellLevelAnalysis(BatchJob):
                                     self.cell_seg_key],
                          input_ndim=input_ndim)
         self.identifier = identifier
-        self.runners = {'default': self.run}
 
     def run(self, input_files, output_files, gpu_id=None):
         with torch.no_grad():

--- a/batchlib/analysis/pixel_level_analysis.py
+++ b/batchlib/analysis/pixel_level_analysis.py
@@ -69,10 +69,10 @@ def all_stats(input_file, output_file, analysis_folde_name="pixelwise_analysis",
     infected_tritc_intensity = compute_weighted_tritc(infected, tritc, "mean")
     not_infected_tritc_intensity = compute_weighted_tritc(not_infected, tritc, "mean")
 
-    result[f"ratio_of_mean_over_mean"] = ratio(infected_tritc_intensity,
-                                               not_infected_tritc_intensity)
-    result[f"dos_of_mean_over_mean"] = difference_over_sum(infected_tritc_intensity,
-                                                           not_infected_tritc_intensity)
+    result["ratio_of_mean_over_mean"] = ratio(infected_tritc_intensity,
+                                              not_infected_tritc_intensity)
+    result["dos_of_mean_over_mean"] = difference_over_sum(infected_tritc_intensity,
+                                                          not_infected_tritc_intensity)
 
     # compute statistics for different choices of quantiles (q = 0.5 == median)
     for q in [0.5]:
@@ -158,7 +158,6 @@ class PixellevelAnalysis(BatchJobWithSubfolder):
                                     self.infection_key],
                          input_ndim=input_ndim)
         self.identifier = identifier
-        self.runners = {'default': self.run}
 
     def run(self, input_files, output_files):
 
@@ -176,7 +175,6 @@ class PixellevelAnalysis(BatchJobWithSubfolder):
 class PixellevelPlots(BatchJob):
     """
     """
-
     def __init__(self,
                  input_pattern='pixelwise_analysis/*.json',
                  output_ext="",
@@ -184,9 +182,7 @@ class PixellevelPlots(BatchJob):
 
         super().__init__(input_pattern,
                          output_ext=output_ext)
-
         self.identifier = identifier
-        self.runners = {'default': self.run}
 
     def run(self, input_files, output_files):
         print("plot histograms for %i input jsons" % (len(input_files), ))

--- a/batchlib/base.py
+++ b/batchlib/base.py
@@ -40,66 +40,23 @@ class BatchJob(ABC):
     # by default, we lock the whole folder and don't need to lock the individual jobs
     lock_job = False
 
-    @staticmethod
-    def check_keys(keys):
-        if keys is None:
-            return None, None
-
-        if not isinstance(keys, (str, list)):
-            raise ValueError("Invalid data keys")
-        if isinstance(keys, list) and not all(isinstance(k, str) for k in keys):
-            raise ValueError("Invalid data keys")
-        exp_keys = [keys] if isinstance(keys, str) else keys
-        return keys, exp_keys
-
-    @staticmethod
-    def check_ndim(ndim, keys):
-        if ndim is None:
-            exp_ndim = None if keys is None else [None] * len(keys)
-            return ndim, exp_ndim
-
-        if isinstance(ndim, (list, tuple)):
-            if len(ndim) != len(keys):
-                raise ValueError("Invalid data ndim")
-            exp_ndim = ndim
-        else:
-            exp_ndim = [ndim] * len(keys)
-        return ndim, exp_ndim
-
-    def __init__(self, input_pattern, output_ext=None,
-                 input_key=None, output_key=None,
-                 input_ndim=None, output_ndim=None):
+    def __init__(self, input_pattern, output_ext=None, identifier=None):
         if not self.hasattr('run'):
             raise AttributeError("Class deriving from BatchJob must implement run method")
-
-        # the input and output keys (= internal datasets)
-        # the _exp_ variables are the normalized versions we need in the checks
-        self.input_key, self._input_exp_key = self.check_keys(input_key)
-        self.output_key, self._output_exp_key = self.check_keys(output_key)
-
-        # the input and output dimensions
-        # the _exp_ variables are the normalized versions we need in the checks
-        self.input_ndim, self._input_exp_ndim = self.check_ndim(input_ndim, self._input_exp_key)
-        self.output_ndim, self._output_exp_ndim = self.check_ndim(output_ndim, self._output_exp_key)
 
         self.input_pattern = input_pattern
         self.input_ext = os.path.splitext(self.input_pattern)[1]
         self.output_ext = self.input_ext if output_ext is None else output_ext
+        if (identifier is not None) or (not isinstance(identifier, str)):
+            raise ValueError("Expect identifier to  be None or string")
+        self.identifier = identifier
 
-    # TODO identifier should be argument to constructor
     @property
     def name(self):
         name_ = self.__class__.__name__
-        # if the class has an identifier member, we add it to the name
-        # this allows running multiple batch jobs of the same type for one
-        # experiment, by adding the identifiers
-        identifier = getattr(self, 'identifier', None)
-        if identifier is None:
-            return name_
-        else:
-            identifier = self.identifier
-            assert isinstance(identifier, str)
-            return name_ + identifier
+        # if the class identifier is not None, it's added to the name
+        # this allows running multiple batch jobs of the same type for one class
+        return name_ if self.identifier is None else name_ + self.identifier
 
     def status_file(self, folder):
         return os.path.join(folder, 'batchlib', self.name + '.status')
@@ -244,6 +201,85 @@ class BatchJob(ABC):
             status = self.update_status(folder, status, processed=True)
             return status['state']
 
+    def check_output(self, path):
+        return os.path.exists(path)
+
+    def validate_input(self, path):
+        return os.path.exists(path)
+
+    # in the default implementation, validate_output just calls
+    # check_output. This is a separate function though to allow
+    # more expensive checks, that are only computed once after
+    # the calculation is finished
+    def validate_output(self, path):
+        return self.check_output(path)
+
+    def get_invalid_inputs(self, inputs):
+        return [path for path in inputs if not self.validate_input(path)]
+
+    def get_invalid_outputs(self, outputs):
+        return [path for path in outputs if not self.validate_output(path)]
+
+
+class BatchJobOnContainer(BatchJob, ABC):
+    """ Base class for batch jobs operating on at least one
+    container file (= h5/n5/zarr file).
+    """
+    supported_container_extensions = {'.h5', '.hdf5', '.zarr', '.zr', '.n5'}
+
+    def __init__(self, input_pattern, output_ext=None, identifier=None,
+                 input_key=None, output_key=None,
+                 input_ndim=None, output_ndim=None):
+        ext = os.path.splitext(input_pattern)[1]
+        if ext.lower() not in self.supported_extensions:
+            raise ValueError("Invalid extension %s in input pattern" % ext)
+        super().__init__(input_pattern=input_pattern,
+                         output_ext=output_ext,
+                         identifier=identifier)
+
+        # the input and output keys (= internal datasets)
+        # the _exp_ variables are the normalized versions we need in the checks
+        self.input_key, self._input_exp_key = self.check_keys(input_key, self.input_ext)
+        self.output_key, self._output_exp_key = self.check_keys(output_key, self.output_ext)
+
+        # the input and output dimensions
+        # the _exp_ variables are the normalized versions we need in the checks
+        self.input_ndim, self._input_exp_ndim = self.check_ndim(input_ndim, self._input_exp_key)
+        self.output_ndim, self._output_exp_ndim = self.check_ndim(output_ndim, self._output_exp_key)
+
+    @staticmethod
+    def check_keys(keys, ext):
+        if keys is None:
+            return None, None
+
+        supported_ext = BatchJobOnContainer.supported_container_extensions
+        if ext.lower not in supported_ext:
+            ext_str = ", ".join(supported_ext)
+            raise ValueError("Invalid container extension %s, expected one of %s" % (ext, ext_str))
+
+        if not isinstance(keys, (str, list)):
+            raise ValueError("Invalid data keys")
+
+        if isinstance(keys, list) and not all(isinstance(k, str) for k in keys):
+            raise ValueError("Invalid data keys")
+
+        exp_keys = [keys] if isinstance(keys, str) else keys
+        return keys, exp_keys
+
+    @staticmethod
+    def check_ndim(ndim, keys):
+        if ndim is None:
+            exp_ndim = None if keys is None else [None] * len(keys)
+            return ndim, exp_ndim
+
+        if isinstance(ndim, (list, tuple)):
+            if len(ndim) != len(keys):
+                raise ValueError("Invalid data ndim")
+            exp_ndim = ndim
+        else:
+            exp_ndim = [ndim] * len(keys)
+        return ndim, exp_ndim
+
     @staticmethod
     def _check_impl(path, exp_keys, exp_ndims):
         if not os.path.exists(path):
@@ -266,49 +302,19 @@ class BatchJob(ABC):
     def validate_input(self, path):
         return self._check_impl(path, self._input_exp_key, self._input_exp_ndim)
 
-    # in the default implementation, validate_output just calls
-    # check_output. This is a separate function though to allow
-    # more expensive checks, that are only computed once after
-    # the calculation is finished
-    def validate_output(self, path):
-        return self.check_output(path)
 
-    def get_invalid_inputs(self, inputs):
-        return [path for path in inputs if not self.validate_input(path)]
-
-    def get_invalid_outputs(self, outputs):
-        return [path for path in outputs if not self.validate_output(path)]
-
-
-# TODO this should still be abstract, how do we do this?
-# maybe move the h5/n5 specific functionality from BatchJob here?
-class BatchJobOnContainer(BatchJob):
-    """ Base class for batch jobs operating on single container (= h5/n5/zarr file).
-    """
-    supported_extensions = {'.h5', '.hdf5', '.zarr', '.zr', '.n5'}
-
-    def __init__(self, input_pattern, input_key, output_key,
-                 input_ndim=None, output_ndim=None):
-        ext = os.path.splitext(input_pattern)[1]
-        if ext.lower() not in self.supported_extensions:
-            raise ValueError("Invalid extension %s in input pattern" % ext)
-        super().__init__(input_pattern=input_pattern, output_ext=None,
-                         input_key=input_key, output_key=output_key,
-                         input_ndim=input_ndim, output_ndim=output_ndim)
-
-
-class BatchJobWithSubfolder(BatchJob):
-    """ Base class for batch jobs that output into a folder
+class BatchJobWithSubfolder(BatchJobOnContainer, ABC):
+    """ Base class for a job that operates on an input container
+    and writes ouput to a sub-folder.
     """
 
-    def __init__(self, input_pattern,
-                 output_folder="", output_ext=None,
+    def __init__(self, input_pattern, output_ext=None,
+                 identifier=None, output_folder="",
                  input_key=None, input_ndim=None):
         self.output_folder = output_folder
 
         super().__init__(input_pattern, output_ext=output_ext,
-                         input_key=input_key, input_ndim=input_ndim,
-                         target='default')
+                         input_key=input_key, input_ndim=input_ndim)
 
     def to_outputs(self, inputs, folder):
         names = [os.path.splitext(os.path.split(inp)[1])[0] for inp in inputs]

--- a/batchlib/preprocessing/preprocess.py
+++ b/batchlib/preprocessing/preprocess.py
@@ -23,7 +23,6 @@ class Preprocess(BatchJob):
         channel_dims = [3, 2, 2, 2]
         super().__init__(input_pattern='*.tiff', output_ext=output_ext,
                          output_key=channel_names_, output_ndim=channel_dims)
-        self.runners = {'default': self.run}
 
     def _reorder(self, im):
         im_new = np.zeros_like(im)

--- a/batchlib/segmentation/seeded_segmentation.py
+++ b/batchlib/segmentation/seeded_segmentation.py
@@ -31,7 +31,6 @@ class SeededSegmentation(BatchJobOnContainer):
         self.pmap_key = pmap_key
         self.seed_key = seed_key
         self.mask_key = mask_key
-        self.runners = {'default': self.run}
 
     def process_mask_and_seeds(self, seeds, mask, erode_mask, dilate_seeds):
         if dilate_seeds > 0:

--- a/batchlib/segmentation/stardist_prediction.py
+++ b/batchlib/segmentation/stardist_prediction.py
@@ -5,11 +5,6 @@ from batchlib.base import BatchJobOnContainer
 from batchlib.util import open_file, write_viewer_attributes, normalize_percentile
 
 
-# TODO (or rather to premature optimize, this is fast enough on single gpu for now!)
-# - implement multi gpu support, would probably need to do IPC through files or
-#    call this script with inputs / outputs in subprocess, it Deadlocked when running
-#    from one process pool
-# - or is there something like torch.data_parallel one could use?
 class StardistPrediction(BatchJobOnContainer):
     """
     """
@@ -26,7 +21,6 @@ class StardistPrediction(BatchJobOnContainer):
 
         self.model_root = model_root
         self.model_name = model_name
-        self.runners = {'default': self.run}
 
     def segment_image(self, in_path, out_path, model):
         with open_file(in_path, 'r') as f:

--- a/batchlib/segmentation/torch_prediction.py
+++ b/batchlib/segmentation/torch_prediction.py
@@ -29,7 +29,6 @@ class TorchPrediction(BatchJobOnContainer):
         self.model_path = model_path
         self.model_class = model_class
         self.model_kwargs = model_kwargs
-        self.runners = {'default': self.run}
 
     def predict_images(self, in_batch, out_batch, model,
                        default_normalize, device, threshold_channels):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup, find_packages
+
+# TODO add all the authors
+# minimal setup script for the mmpb package
+setup(
+    name="batchlib",
+    packages=find_packages(exclude=["test"]),
+    version='0.1.0',
+    url="https://github.com/hci-unihd/batchlib.git"
+    # author="Constantin Pape",
+)


### PR DESCRIPTION
- Remove the `self.runners` pattern. This is not a good design pattern to support running on different computation targets, see #5 and obfuscates the code. For now, we also don't need this. To run on slurm, we can just submit  a task for processing a full plate.
- Move hdf5/n5 specific functionality to `BatchJobOnCluster`.
- Some more minor clean up.