### PR TITLE
Skip outliers in the analysis workflow

### DIFF
--- a/antibodies/instance_analysis_workflow1.py
+++ b/antibodies/instance_analysis_workflow1.py
@@ -122,10 +122,10 @@ def parse_instance_config1():
 
     # tagged outliers from a given plate
     # if plate_name is empty we will try to infer it from the 'input_folder' name
-    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name (or names) of the imaged plate")
+    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name of the imaged plate")
     # if outliers_dir is empty, ../misc/tagged_outliers will be used
     parser.add("--outliers_dir", default=None, type=str,
-               help="Path to the directory where containing CSV files with marked outliers")
+               help="Path to the directory containing CSV files with marked outliers")
 
     return parser.parse_args()
 

--- a/antibodies/instance_analysis_workflow1.py
+++ b/antibodies/instance_analysis_workflow1.py
@@ -41,6 +41,8 @@ def run_instance_analysis1(config):
 
     n_threads_il = None if config.n_cpus == 1 else 4
 
+    outlier_predicate = get_outlier_predicate(config)
+
     job_dict = {
         Preprocess.from_folder: {'build': {'input_folder': config.input_folder,
                                            'barrel_corrector_path': barrel_corrector_path},
@@ -68,7 +70,8 @@ def run_instance_analysis1(config):
                                   'n_jobs': config.n_cpus}},
         CellLevelAnalysis: {'build': {'raw_key': config.in_key,
                                       'nuc_seg_key': config.nuc_key,
-                                      'cell_seg_key': config.seg_key},
+                                      'cell_seg_key': config.seg_key,
+                                      'outlier_predicate': outlier_predicate},
                             'run': {'gpu_id': config.gpu}}
     }
 
@@ -116,6 +119,13 @@ def parse_instance_config1():
 
     default_scale_factors = [1, 2, 4, 8]
     parser.add("--scale_factors", default=default_scale_factors)
+
+    # tagged outliers from a given plate
+    # if plate_name is empty we will try to infer it from the 'input_folder' name
+    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name (or names) of the imaged plate")
+    # if outliers_dir is empty, ../misc/tagged_outliers will be used
+    parser.add("--outliers_dir", default=None, type=str,
+               help="Path to the directory where containing CSV files with marked outliers")
 
     return parser.parse_args()
 

--- a/antibodies/instance_analysis_workflow2.py
+++ b/antibodies/instance_analysis_workflow2.py
@@ -212,10 +212,10 @@ def parser():
 
     # tagged outliers from a given plate
     # if plate_name is empty we will try to infer it from the 'input_folder' name
-    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name (or names) of the imaged plate")
+    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name of the imaged plate")
     # if outliers_dir is empty, ../misc/tagged_outliers will be used
     parser.add("--outliers_dir", default=None, type=str,
-               help="Path to the directory where containing CSV files with marked outliers")
+               help="Path to the directory containing CSV files with marked outliers")
 
     return parser
 

--- a/antibodies/instance_analysis_workflow2.py
+++ b/antibodies/instance_analysis_workflow2.py
@@ -10,6 +10,7 @@ from batchlib import run_workflow
 from batchlib.analysis.cell_level_analysis import CellLevelAnalysis
 from batchlib.analysis.pixel_level_analysis import all_plots
 from batchlib.analysis.summary import Summary
+from batchlib.outliers.outlier import get_outlier_predicate
 from batchlib.preprocessing import Preprocess
 from batchlib.segmentation import SeededWatershed
 from batchlib.segmentation.stardist_prediction import StardistPrediction
@@ -77,6 +78,8 @@ def run_instance_analysis2(config):
      marker_ana_in_key, serum_ana_in_key) = get_input_keys(config)
     analysis_folder = 'instancewise_analysis_corrected' if config.analysis_on_corrected else 'instancewise_analysis'
 
+    outlier_predicate = get_outlier_predicate(config)
+
     job_dict = {
         Preprocess.from_folder: {'build': {'input_folder': config.input_folder,
                                            'barrel_corrector_path': barrel_corrector_path,
@@ -110,12 +113,14 @@ def run_instance_analysis2(config):
                                       'marker_key': marker_ana_in_key,
                                       'nuc_seg_key': config.nuc_key,
                                       'cell_seg_key': config.seg_key,
-                                      'output_folder': analysis_folder},
+                                      'output_folder': analysis_folder,
+                                      'outlier_predicate': outlier_predicate},
                             'run': {'gpu_id': config.gpu}},
         Summary: {'build': {'serum_key': serum_ana_in_key,
                             'marker_key': marker_ana_in_key,
                             'cell_seg_key': config.seg_key,
-                            'analysis_folder': analysis_folder},
+                            'analysis_folder': analysis_folder,
+                            'outlier_predicate': outlier_predicate},
                   'run': {}}
     }
 
@@ -204,6 +209,13 @@ def parser():
     # default_scale_factors = None
     default_scale_factors = [1, 2, 4, 8]
     parser.add("--scale_factors", default=default_scale_factors)
+
+    # tagged outliers from a given plate
+    # if plate_name is empty we will try to infer it from the 'input_folder' name
+    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name (or names) of the imaged plate")
+    # if outliers_dir is empty, ../misc/tagged_outliers will be used
+    parser.add("--outliers_dir", default=None, type=str,
+               help="Path to the directory where containing CSV files with marked outliers")
 
     return parser
 

--- a/antibodies/pixel_analysis_workflow1.py
+++ b/antibodies/pixel_analysis_workflow1.py
@@ -152,10 +152,10 @@ def parser():
 
     # tagged outliers from a given plate
     # if plate_name is empty we will try to infer it from the 'input_folder' name
-    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name (or names) of the imaged plate")
+    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name of the imaged plate")
     # if outliers_dir is empty, ../misc/tagged_outliers will be used
     parser.add("--outliers_dir", default=None, type=str,
-               help="Path to the directory where containing CSV files with marked outliers")
+               help="Path to the directory containing CSV files with marked outliers")
 
     return parser
 

--- a/antibodies/pixel_analysis_workflow1.py
+++ b/antibodies/pixel_analysis_workflow1.py
@@ -8,6 +8,7 @@ from glob import glob
 
 from batchlib import run_workflow
 from batchlib.analysis import PixellevelAnalysis, all_plots
+from batchlib.outliers.outlier import get_outlier_predicate
 from batchlib.preprocessing import Preprocess
 from batchlib.segmentation import IlastikPrediction
 from batchlib.util.logging import get_logger
@@ -59,6 +60,8 @@ def run_pixel_analysis1(config):
 
     barrel_corrector_path = os.path.join(os.path.split(__file__)[0], '../misc/', config.barrel_corrector)
 
+    outlier_predicate = get_outlier_predicate(config)
+
     job_dict = {
         Preprocess.from_folder: {'build': {'input_folder': config.input_folder,
                                            'barrel_corrector_path': barrel_corrector_path,
@@ -75,7 +78,8 @@ def run_pixel_analysis1(config):
         PixellevelAnalysis: {'build': {'serum_key': serum_ana_in_key,
                                        'infected_key': config.out_key_infected,
                                        'not_infected_key': config.out_key_not_infected,
-                                       'output_folder': analysis_folder},
+                                       'output_folder': analysis_folder,
+                                       'outlier_predicate': outlier_predicate},
                              'run': {'n_jobs': config.n_cpus}}
     }
 
@@ -145,6 +149,13 @@ def parser():
     parser.add("--force_recompute", default=None)
     parser.add("--ignore_invalid_inputs", default=None)
     parser.add("--ignore_failed_outputs", default=None)
+
+    # tagged outliers from a given plate
+    # if plate_name is empty we will try to infer it from the 'input_folder' name
+    parser.add("--plate_name", default=None, nargs='+', type=str, help="The name (or names) of the imaged plate")
+    # if outliers_dir is empty, ../misc/tagged_outliers will be used
+    parser.add("--outliers_dir", default=None, type=str,
+               help="Path to the directory where containing CSV files with marked outliers")
 
     return parser
 

--- a/batchlib/analysis/pixel_level_analysis.py
+++ b/batchlib/analysis/pixel_level_analysis.py
@@ -102,7 +102,9 @@ class PixellevelAnalysis(BatchJobWithSubfolder):
                  not_infected_key='local_not_infected',
                  input_pattern='*.h5',
                  output_folder="pixelwise_analysis",
-                 identifier=None):
+                 identifier=None,
+                 outlier_predicate=lambda im: False):
+
         self.serum_key = serum_key
         self.infected_key = infected_key
         self.not_infected_key = not_infected_key
@@ -120,7 +122,9 @@ class PixellevelAnalysis(BatchJobWithSubfolder):
                                     self.infected_key,
                                     self.not_infected_key],
                          input_ndim=input_ndim)
+
         self.identifier = identifier
+        self.outlier_predicate = outlier_predicate
 
     def load_sample(self, path):
         with open_file(path, mode='r') as f:
@@ -142,6 +146,9 @@ class PixellevelAnalysis(BatchJobWithSubfolder):
         return infected, not_infected, serum, background_intensity
 
     def all_stats(self, input_file, output_file):
+        if self.outlier_predicate(input_file):
+            logger.info(f'Excluding outlier from analysis: {input_file}')
+            return
 
         infected, not_infected, serum, bg_intensity = self.load_sample(input_file)
         result = {}

--- a/batchlib/analysis/summary.py
+++ b/batchlib/analysis/summary.py
@@ -25,7 +25,9 @@ class Summary(BatchJobOnContainer):
                  serum_per_cell_mean_key='serum_per_cell_mean',
                  score_key='ratio_of_median_of_means',
                  analysis_folder='instancewise_analysis_corrected',
-                 input_pattern='*.h5', **super_kwargs):
+                 input_pattern='*.h5',
+                 outlier_predicate=lambda im: False,
+                 **super_kwargs):
         self.cell_seg_key = cell_seg_key
         self.serum_key = serum_key
         self.marker_key = marker_key
@@ -35,6 +37,7 @@ class Summary(BatchJobOnContainer):
 
         self.infected_cell_mask_key = infected_cell_mask_key
         self.serum_per_cell_mean_key = serum_per_cell_mean_key
+        self.outlier_predicate = outlier_predicate
 
         input_ndim = [2]
 
@@ -66,15 +69,17 @@ class Summary(BatchJobOnContainer):
                         'num_infected_cells',
                         'num_not_infected_cells',
                         'background_percentage',
+                        'outlier',
                         ] + list(measures[0].keys())
 
         column_dict = {site_name: [measures[i][self.score_key],
                                    num_cells[i],
                                    num_infected_cells[i],
                                    num_not_infected_cells[i],
-                                   background_percentages[i]
+                                   background_percentages[i],
+                                   self.outlier_predicate(im_name)
                                    ] + list(measures[i].values())
-                       for i, site_name in enumerate(site_names)}
+                       for i, (im_name, site_name) in enumerate(zip(im_names, site_names))}
         # replace None with "NaN"
         column_dict = {site_name: [value if value is not None else 'NaN'
                                    for value in values]

--- a/batchlib/outliers/outlier.py
+++ b/batchlib/outliers/outlier.py
@@ -2,6 +2,43 @@ import csv
 import glob
 import os
 
+from batchlib.util.logging import get_logger
+
+logger = get_logger('Workflow.Outliers')
+
+DEFAULT_OUTLIER_DIR = os.path.join(os.path.split(__file__)[0], '../../misc/tagged_outliers')
+
+
+def get_outlier_predicate(config):
+    if hasattr(config, 'outliers_dir') and config.outliers_dir is not None:
+        outliers_dir = config.outliers_dir
+    else:
+        outliers_dir = DEFAULT_OUTLIER_DIR
+
+    if hasattr(config, 'plate_name') and config.plate_name is not None:
+        plate_name = config.plate_name
+    else:
+        logger.info(f"Trying to parse 'plate_name' from the input folder: {config.input_folder}")
+        plate_name = plate_name_from_input_folder(config.input_folder)
+        if plate_name is not None:
+            logger.info(f"'plate_name' found: {plate_name}")
+        else:
+            # return default predicate, i.e. treat all images as non-outliers
+            return lambda im: False
+
+    # TODO: change Outliers interface
+    return Outliers(root_table_dir=outliers_dir, plate_name=plate_name)
+
+
+def plate_name_from_input_folder(input_folder):
+    for csv_file in glob.glob(os.path.join(DEFAULT_OUTLIER_DIR, '*.csv')):
+        plate_name = os.path.split(csv_file)[1]
+        plate_name = plate_name[:plate_name.find('_tagger')]
+
+        if plate_name in input_folder:
+            return plate_name
+    return None
+
 
 class Outliers:
     def __init__(self, root_table_dir):
@@ -36,7 +73,7 @@ class Outliers:
 
     def is_outlier(self, plate_name, img_file):
         """
-        Returns True if a given image (img_file) from a given well (well_name) is an outlier, False otherwise.
+        Returns True if a given image (img_file) from a given plate (plate_name) is an outlier, False otherwise.
         WARN: currently we treat everything not labeled as 0 to be an outlier (i.e. images labeled as skipped -1
         are counted as outliers).
         """

--- a/test/outliers/test_outlier.py
+++ b/test/outliers/test_outlier.py
@@ -2,20 +2,20 @@ import os
 import unittest
 from pathlib import Path
 
-from batchlib.outliers.outlier import Outliers, plate_name_from_input_folder
+from batchlib.outliers.outlier import OutlierPredicate, plate_name_from_input_folder
 
 
 class TestOutliers(unittest.TestCase):
     _global_path = os.path.join(Path(__file__).parent.parent.parent.absolute(), 'misc/tagged_outliers')
 
     def test_outliers(self):
-        outliers = Outliers(self._global_path)
+        outliers = OutlierPredicate(self._global_path)
         plate_name = '20200406_164555_328'
         img_name = 'WellA01_PointA01_0008_ChannelDAPI,WF_GFP,TRITC_Seq0008'
         assert outliers.is_outlier(plate_name, img_name)
 
     def test_outlier_number(self):
-        outliers = Outliers(self._global_path)
+        outliers = OutlierPredicate(self._global_path)
         plate_count = {}
         total_outlier_count = 0
         total_count = 0

--- a/test/outliers/test_outlier.py
+++ b/test/outliers/test_outlier.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from pathlib import Path
 
-from batchlib.outliers.outlier import Outliers
+from batchlib.outliers.outlier import Outliers, plate_name_from_input_folder
 
 
 class TestOutliers(unittest.TestCase):
@@ -35,3 +35,10 @@ class TestOutliers(unittest.TestCase):
         for k, v in plate_count.items():
             print(f'{k}: {v}')
         print(f'\nTotal outlier count: {total_outlier_count / total_count}')
+
+    def test_plate_name_from_input_folder(self):
+        input_folder = '/home/covid19/data/20200410_145132_254'
+
+        plate_name = plate_name_from_input_folder(input_folder)
+
+        assert plate_name is not None


### PR DESCRIPTION
Fixes https://github.com/hci-unihd/batchlib/issues/31

Skips outlier images from the analysis stage of the workflow. User can pass additional parameters when running the `instance_analysis_workflow1(2)` and `pixel_analysis_workflow`:
- `outliers_dir` - path to the directory containing CSV files with marked outliers; if no path is provided default `misc/tagged_outliers` will be taken
- `plate_name` - the name of the plate to be processed (e.g. `20200406_164555_328`) if no plate name is provided the module will try to parse it base on the `input_folder` name (e.g. `/home/covid19/data/20200406_164555_328`); it the name cannot be parsed a default predictor will be used, which accepts all images for analysis.

Based on the `outlier_dir` and `plate_name` an instance of `outlier_predictor` is passed to `CellLevelAnalysis`, `PixellevelAnalysis` and `Summary`. 
Currently the images are skipped from the analysis in `PixellevelAnalysis` and `CellLevelAnalysis`  if `outlier_predictor` returns `true`. It might be helpful however to have another flag, e.g. `--skip_in_summary_only`, which only marks the outliers in the summary table, but proceed with the analysis as usual. It might be beneficial especially at the beginning, when we're still unsure what is a legitimate outlier and what is still 'analyzable'...