### PR TITLE
Save tables for all serum channels in same *_table.hdf5

### DIFF
--- a/batchlib/analysis/cell_level_analysis.py
+++ b/batchlib/analysis/cell_level_analysis.py
@@ -451,8 +451,7 @@ class CellLevelAnalysisBase(BatchJobOnContainer):
     @staticmethod
     def folder_to_table_path(folder, identifier):
         # NOTE, we call this .hdf5 to avoid pattern matching, it's a bit hacky ...
-        table_file_name = os.path.split(folder)[1] + \
-                          ('_table.hdf5' if identifier is None else f'_table_{identifier}.hdf5')
+        table_file_name = os.path.split(folder)[1] + '_table.hdf5'
         return os.path.join(folder, table_file_name)
 
     @property
@@ -601,10 +600,6 @@ class CellLevelAnalysisWithTableBase(CellLevelAnalysisBase):
 class CellLevelAnalysis(CellLevelAnalysisWithTableBase):
     """
     """
-    # for now, we hard-code the table keys and write to different table files instead
-    image_table_key = 'images/default'
-    well_table_key = 'wells/default'
-
     def __init__(self,
                  cell_seg_key='cell_segmentation',
                  serum_key='serum',
@@ -618,7 +613,12 @@ class CellLevelAnalysis(CellLevelAnalysisWithTableBase):
                  edge_key='cell_segmentation_edges',
                  cell_outlier_table_name='outliers',  # FIXME where should this be used?
                  image_outlier_table='images/outliers',
+                 identifier=None,
                  **super_kwargs):
+
+        # table keys in the plate-wise *_table.hdf5
+        self.image_table_key = f'images/{identifier if identifier is not None else "default"}'
+        self.well_table_key = f'wells/{identifier if identifier is not None else "default"}'
 
         self.score_name = score_name
         self.write_summary_images = write_summary_images
@@ -644,6 +644,7 @@ class CellLevelAnalysis(CellLevelAnalysisWithTableBase):
                          serum_bg_key=serum_bg_key,
                          marker_bg_key=marker_bg_key,
                          output_key=output_key,
+                         identifier=identifier,
                          **super_kwargs)
 
         output_group = cell_seg_key if self.identifier is None else cell_seg_key + '_' + self.identifier

--- a/batchlib/workflows/cell_analysis.py
+++ b/batchlib/workflows/cell_analysis.py
@@ -228,12 +228,12 @@ def run_cell_analysis(config):
     for identifier in table_identifiers:
         table_path = CellLevelAnalysis.folder_to_table_path(config.folder, identifier)
         all_plots(table_path, plot_folder,
-                  table_key=f'tables/{CellLevelAnalysis.image_table_key}',
+                  table_key=f'tables/images/{identifier}',
                   identifier=identifier + '_per-image',
                   stat_names=stat_names,
                   wedge_width=0.3)
         all_plots(table_path, plot_folder,
-                  table_key=f'tables/{CellLevelAnalysis.well_table_key}',
+                  table_key=f'tables/wells/{identifier}',
                   identifier=identifier + '_per-well',
                   stat_names=stat_names,
                   wedge_width=0)


### PR DESCRIPTION
Addresses #84.
For a typical two-serum channel plate The output of `h5ls` on the output table now looks like this:

```
/                        Group
/tables                  Group
/tables/images           Group
/tables/images/outliers  Group
/tables/images/outliers/cells Dataset {18, 4}
/tables/images/outliers/columns Dataset {4}
/tables/images/outliers/visible Dataset {4}
/tables/images/serum_IgA_corrected Group
/tables/images/serum_IgA_corrected/cells Dataset {18, 146}
/tables/images/serum_IgA_corrected/columns Dataset {146}
/tables/images/serum_IgA_corrected/visible Dataset {146}
/tables/images/serum_IgG_corrected Group
/tables/images/serum_IgG_corrected/cells Dataset {18, 146}
/tables/images/serum_IgG_corrected/columns Dataset {146}
/tables/images/serum_IgG_corrected/visible Dataset {146}
/tables/wells            Group
/tables/wells/serum_IgA_corrected Group
/tables/wells/serum_IgA_corrected/cells Dataset {2, 140}
/tables/wells/serum_IgA_corrected/columns Dataset {140}
/tables/wells/serum_IgA_corrected/visible Dataset {140}
/tables/wells/serum_IgG_corrected Group
/tables/wells/serum_IgG_corrected/cells Dataset {2, 140}
/tables/wells/serum_IgG_corrected/columns Dataset {140}
/tables/wells/serum_IgG_corrected/visible Dataset {140}
```