### PR TITLE
Update cohort ids if automatically in DbResultWriter 

### DIFF
--- a/batchlib/mongo/result_writer.py
+++ b/batchlib/mongo/result_writer.py
@@ -6,9 +6,11 @@ import h5py
 from pymongo import MongoClient
 
 from batchlib.base import BatchJobOnContainer
+from batchlib.mongo.import_cohort_ids import import_cohort_ids_for_plate
 from batchlib.mongo.utils import ASSAY_ANALYSIS_RESULTS, ASSAY_METADATA, create_plate_doc, parse_workflow_duration, \
     parse_workflow_name, parse_plate_dir
 from batchlib.util import get_logger, get_commit_id
+from batchlib.util.cohort_parser import CohortIdParser
 from batchlib.util.io import read_table
 
 logger = get_logger('Workflow.BatchJob.DbResultWriter')
@@ -127,3 +129,7 @@ class DbResultWriter(BatchJobOnContainer):
         plate_dir = parse_plate_dir(work_dir, default_dir=self.folder)
         plate_doc = create_plate_doc(plate_name, plate_dir)
         self.db[ASSAY_METADATA].find_one_and_replace({"name": plate_name}, plate_doc, upsert=True)
+
+        # update cohort ids if present for the plate
+        cohort_id_parser = CohortIdParser()
+        import_cohort_ids_for_plate(plate_name, self.db[ASSAY_METADATA], cohort_id_parser)


### PR DESCRIPTION
Update cohort ids for a given plate automatically in the `DbResultWriter` if the cohort excel file is present.

This will work only if the result doc for a given plate is not already present in the `immuno-assay-analysis-results` (see `DbResultWriter.check_output`) or `force_recompute=True` for the `DbResultWriter` job.